### PR TITLE
Refactoring of VaspToDbTaskDrone

### DIFF
--- a/matgendb/creator.py
+++ b/matgendb/creator.py
@@ -188,11 +188,6 @@ class VaspToDbTaskDrone(AbstractDrone):
     def get_task_doc(self, path):
         """
         Get the entire task doc for a path, including any post-processing.
-        Args:
-            runs:
-                Ordered list of runs to look for e.g. ["relax1", "relax2"].
-                Automatically detects whether the runs are stored in the
-                subfolder or file extension schema.
         """
         logger.info("Getting task doc for base dir :{}".format(path))
         files = os.listdir(path)


### PR DESCRIPTION
Backwards incompatible (just for subclasses) - I'd like someone from MP to sign off on this first (no nosetests in MPWorks). 

Allow for more flexible custodianformats (different numbers of runs, etc).
BACKWARDS INCOMPATIBLE!! All classmethods have been removed (and
therefore inheriting classes needs to be adjusted accordingly)
Other changes _should_ be backwards compatible, except for edge cases
where extra vaspruns (in addition to relax1 and relax2) are found in
the run folder.
