### PR TITLE
Restore full list of stuff mgdb init asks for

### DIFF
--- a/matgendb/dbconfig.py
+++ b/matgendb/dbconfig.py
@@ -26,6 +26,7 @@ DB_KEY = "database"
 COLL_KEY = "collection"
 USER_KEY = "user"
 PASS_KEY = "password"
+ALIASES_KEY = "aliases"
 
 class ConfigurationFileError(Exception):
     def __init__(self, filename, err):
@@ -38,10 +39,18 @@ class DBConfig(object):
 
     DEFAULT_PORT = 27017
     DEFAULT_FILE = 'db.json'
+    ALL_SETTINGS = [
+        HOST_KEY,
+        PORT_KEY,
+        DB_KEY,
+        COLL_KEY,
+        ALIASES_KEY,
+    ]
     DEFAULT_SETTINGS = [
         (HOST_KEY, "localhost"),
         (PORT_KEY, DEFAULT_PORT),
-        (DB_KEY, "vasp")
+        (DB_KEY, "vasp"),
+        (ALIASES_KEY, {}),
     ]
 
     def __init__(self, config_file=None, config_dict=None):

--- a/matgendb/tests/test_dbconfig.py
+++ b/matgendb/tests/test_dbconfig.py
@@ -66,7 +66,8 @@ class SettingsTestCase(unittest.TestCase):
             "port": 27017,
             "database": u"foo",
             "user": u"guy",
-            "password": u"knock-knock"
+            "password": u"knock-knock",
+            "aliases": {},
         }
         self.tmp = tempfile.NamedTemporaryFile("r+")
         json.dump(self.cfg, self.tmp)

--- a/scripts/mgdb
+++ b/scripts/mgdb
@@ -27,16 +27,19 @@ from pymatgen.apps.borg.queen import BorgQueen
 
 from matgendb.query_engine import QueryEngine
 from matgendb.creator import VaspToDbTaskDrone
+from matgendb.dbconfig import DBConfig
 from matgendb.util import get_settings, DEFAULT_SETTINGS, MongoJSONEncoder
 
 _log = logging.getLogger("mg")  # parent
 
 def init_db(args):
-    d = DEFAULT_SETTINGS
+    settings = DBConfig.ALL_SETTINGS
+    defaults = dict(DEFAULT_SETTINGS)
     doc = {}
     print("Please supply the following configuration values")
     print("(press Enter if you want to accept the defaults)\n")
-    for k, v in d:
+    for k in settings:
+        v = defaults.get(k, '')
         val = raw_input("Enter {} (default: {}) : ".format(k, v))
         doc[k] = val if val else v
     doc["port"] = int(doc["port"])  # enforce the port as an int


### PR DESCRIPTION
Left DEFAULT_SETTINGS minimal, but added ALL_SETTINGS that has the full list. Use this instead in the mgdb script (pulling defaults from DEFAULT_SETTINGS, of course)
