### PR TITLE
fix: restore import, with py3 compat

### DIFF
--- a/matgendb/builders/core.py
+++ b/matgendb/builders/core.py
@@ -14,6 +14,10 @@ from abc import ABCMeta, abstractmethod
 import copy
 import logging
 import multiprocessing
+try:
+    import Queue
+except ImportError:
+    import queue as Queue
 import traceback
 # local
 from matgendb.builders import schema, util
@@ -81,7 +85,7 @@ def parse_fn_docstring(fn):
 
 class Collections(object):
     """Interface to normalized names for collections.
-    
+
     After initialization with a MongoDB database and optional parameters,
     you can access collections in `known_collections` as attributes.
     """
@@ -141,7 +145,7 @@ class Collections(object):
     @property
     def database(self):
         """Return the current database object.
-        
+
         :return: Current database object
         """
         return self._db


### PR DESCRIPTION
In e0cefcaa8b98b40acee3e914e24bfeca82d7eb95, `import Queue` was removed, presumably to get tests to pass for Python 3. This PR makes the import py3-compatible while restoring module functionality for py2.