### PR TITLE
fix pymatgen core import error and yaml load deprecation warning

### DIFF
--- a/matgendb/__init__.py
+++ b/matgendb/__init__.py
@@ -23,7 +23,7 @@ def _load_mgdb_settings():
     try:
         import yaml
         with open(SETTINGS_FILE, 'rt') as f:
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
     except IOError:
         return {}
     return d

--- a/matgendb/dbconfig.py
+++ b/matgendb/dbconfig.py
@@ -140,7 +140,7 @@ def get_settings(infile):
     :return: Settings parsed from file
     :rtype: dict
     """
-    settings = yaml.load(_as_file(infile))
+    settings = yaml.safe_load(_as_file(infile))
     if not hasattr(settings, 'keys'):
         raise ValueError("Settings not found in {}".format(infile))
 

--- a/matgendb/query_engine.py
+++ b/matgendb/query_engine.py
@@ -22,7 +22,7 @@ from collections import OrderedDict, Iterable
 
 import pymongo
 from pymongo import MongoClient
-from pymatgen import Structure, Composition
+from pymatgen.core import Structure, Composition
 from pymatgen.electronic_structure.core import Orbital, Spin
 from pymatgen.electronic_structure.dos import CompleteDos, Dos
 from pymatgen.entries.computed_entries import ComputedEntry,\


### PR DESCRIPTION
With the latest PyPI releases

```sh
pymatgen==2022.0.5
pymatgen-db==2019.3.28
```

running  `mgdb` throws

```py
Traceback (most recent call last):
  File "/home/jr769/miniconda3/envs/py38/bin/mgdb", line 26, in <module>
    from matgendb import SETTINGS
  File "/home/jr769/miniconda3/envs/py38/lib/python3.8/site-packages/matgendb/__init__.py", line 17, in <module>
    from .query_engine import QueryEngine
  File "/home/jr769/miniconda3/envs/py38/lib/python3.8/site-packages/matgendb/query_engine.py", line 26, in <module>
    from pymatgen import Structure, Composition
ImportError: cannot import name 'Structure' from 'pymatgen' (unknown location)
login-e-13 ~/atomate main$ mgdb query -c config/db.json --props task_id formula_pretty
/home/jr769/miniconda3/envs/py38/lib/python3.8/site-packages/matgendb/__init__.py:26: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  d = yaml.load(f)
```

This PR should fix both the `ImportError` and the `YAMLLoadWarning`.