### PR TITLE
fix missing package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.rst LICENSE *.cfg ez_setup.py VERSION
-recursive-include matgendb *
+recursive-include pymatgen *
 recursive-include scripts *
 prune */*/tests
 prune */*/*/tests

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     extras_require={
         'tests': 'mongomock'
     },
-    package_data={"matgendb": ["*.json"]},
+    package_data={"pymatgen": ["db/*.json"]},
+    include_package_data=True,
     author="Shyue Ping Ong, Dan Gunter",
     author_email="shyuep@gmail.com",
     maintainer="Dan Gunter",

--- a/tasks.py
+++ b/tasks.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Deployment file to facilitate releases of matgendb.
+Deployment file to facilitate releases of pymatgen-db.
 """
 
 from __future__ import division


### PR DESCRIPTION
## Summary

The packaging part still uses the previous name "matgendb" for package data inclusion, causing missing files in the wheel and the source distribution. 

This PR corrected the name to the updated one. 
