### PR TITLE
Use collections.abc rather than collections

### DIFF
--- a/pymatgen/db/query_engine.py
+++ b/pymatgen/db/query_engine.py
@@ -18,7 +18,8 @@ import logging
 import os
 import gridfs
 import zlib
-from collections import OrderedDict, Iterable
+from collections import OrderedDict
+from collections.abc import Iterable
 
 import pymongo
 from pymongo import MongoClient


### PR DESCRIPTION
Required for Python 3.10 compatibility https://github.com/conda-forge/pymatgen-db-feedstock/pull/11 